### PR TITLE
Refactor to LocalDate

### DIFF
--- a/app/src/main/java/com/sherryyuan/wordy/database/Converters.kt
+++ b/app/src/main/java/com/sherryyuan/wordy/database/Converters.kt
@@ -8,7 +8,7 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.ToJson
 import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import java.util.Date
+import java.time.LocalDate
 
 
 class GoalTypeConverter {
@@ -22,27 +22,38 @@ class GoalTypeConverter {
         .add(KotlinJsonAdapterFactory())
         .build()
 
-    private val adapter: JsonAdapter<Goal> = moshi.adapter(Goal::class.java)
+    private val goalAdapter: JsonAdapter<Goal> = moshi.adapter(Goal::class.java)
+    private val dateAdapter: JsonAdapter<LocalDate> = moshi.adapter(LocalDate::class.java)
 
     @TypeConverter
     fun fromGoal(goal: Goal?): String? {
-        return goal?.let { adapter.toJson(it) }
+        return goal?.let { goalAdapter.toJson(it) }
     }
 
     @TypeConverter
     fun toGoal(json: String?): Goal? {
-        return json?.let { adapter.fromJson(it) }
+        return json?.let { goalAdapter.fromJson(it) }
+    }
+
+    @TypeConverter
+    fun fromLocalDate(date: LocalDate?): String? {
+        return date?.let { dateAdapter.toJson(it) }
+    }
+
+    @TypeConverter
+    fun toLocalDate(json: String?): LocalDate? {
+        return json?.let { dateAdapter.fromJson(it) }
     }
 }
 
 class DateJsonAdapter {
     @ToJson
-    fun toJson(date: Date): Long {
-        return date.time
+    fun toJson(date: LocalDate): String {
+        return date.toString()
     }
 
     @FromJson
-    fun fromJson(timestamp: Long): Date {
-        return Date(timestamp)
+    fun fromJson(dateString: String): LocalDate {
+        return LocalDate.parse(dateString)
     }
 }

--- a/app/src/main/java/com/sherryyuan/wordy/database/DailyEntryDao.kt
+++ b/app/src/main/java/com/sherryyuan/wordy/database/DailyEntryDao.kt
@@ -7,6 +7,7 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import com.sherryyuan.wordy.entitymodels.DailyEntry
 import kotlinx.coroutines.flow.Flow
+import java.time.LocalDate
 
 @Dao
 interface DailyEntryDao {
@@ -14,14 +15,14 @@ interface DailyEntryDao {
     @Query(value = "SELECT * FROM DailyEntry")
     fun getAll(): Flow<List<DailyEntry>>
 
-    @Query(value = "SELECT * FROM DailyEntry WHERE timestamp= :timestamp")
-    suspend fun getEntryForTimestamp(timestamp: Long): DailyEntry?
+    @Query(value = "SELECT * FROM DailyEntry WHERE date= :date")
+    suspend fun getEntryForDate(date: LocalDate): DailyEntry?
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertEntry(entry: DailyEntry)
 
-    @Query(value = "UPDATE DailyEntry SET timestamp= :timestamp, wordCount= :wordCount, projectId = :projectId WHERE id = :entryId")
-    suspend fun updateEntry(entryId: Long, timestamp: Long, wordCount: Int, projectId: Long)
+    @Query(value = "UPDATE DailyEntry SET date= :date, wordCount= :wordCount, projectId = :projectId WHERE id = :entryId")
+    suspend fun updateEntry(entryId: Long, date: LocalDate, wordCount: Int, projectId: Long)
 
     @Delete
     suspend fun deleteEntry(entry: DailyEntry)

--- a/app/src/main/java/com/sherryyuan/wordy/entitymodels/DailyEntry.kt
+++ b/app/src/main/java/com/sherryyuan/wordy/entitymodels/DailyEntry.kt
@@ -2,13 +2,13 @@ package com.sherryyuan.wordy.entitymodels
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import java.time.LocalDate
 
 @Entity
 data class DailyEntry(
     @PrimaryKey(autoGenerate = true)
     val id: Long = 0,
-    // timestamp in millis at start of day
-    val timestamp: Long,
+    val date: LocalDate,
     val wordCount: Int,
     val projectId: Long,
 )

--- a/app/src/main/java/com/sherryyuan/wordy/notification/NotificationBroadcastReceiver.kt
+++ b/app/src/main/java/com/sherryyuan/wordy/notification/NotificationBroadcastReceiver.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import java.time.LocalDate
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -43,7 +44,7 @@ class NotificationBroadcastReceiver : BroadcastReceiver() {
                     notificationConfig.showRemoteInputWarningFlow.emit(wordCount == null)
                     if (selectedProject != null && wordCount != null) {
                         entryRepository.insertEntry(
-                            timestamp = System.currentTimeMillis(),
+                            date = LocalDate.now(),
                             wordCount = wordCount,
                             projectId = selectedProject.id,
                             updateWordCountStrategy = EntryRepository.UpdateWordCountStrategy.ADD,
@@ -62,7 +63,7 @@ class NotificationBroadcastReceiver : BroadcastReceiver() {
                     notificationConfig.showRemoteInputWarningFlow.emit(wordCount == null)
                     if (selectedProject != null && wordCount != null) {
                         entryRepository.insertEntry(
-                            timestamp = System.currentTimeMillis(),
+                            date = LocalDate.now(),
                             wordCount = wordCount,
                             projectId = selectedProject.id,
                             updateWordCountStrategy = EntryRepository.UpdateWordCountStrategy.REPLACE,

--- a/app/src/main/java/com/sherryyuan/wordy/notification/NotificationWorker.kt
+++ b/app/src/main/java/com/sherryyuan/wordy/notification/NotificationWorker.kt
@@ -75,15 +75,15 @@ class NotificationWorker @AssistedInject constructor(
             entryRepository.getEntries(),
             notificationConfig.showRemoteInputWarningFlow,
         ) { selectedProject, entries, showRemoteInputWarning ->
-            val wordCount = entries
+            val selectedProjectEntries = entries.filter { it.projectId == selectedProject?.id }
+            val wordCount = selectedProjectEntries
                 .fromPastDays(1)
-                .filter { it.projectId == selectedProject?.id }
                 .sumOf { it.wordCount }
             if (selectedProject == null) return@combine
 
             val wordCountGoal = when (val goal = selectedProject.goal) {
                 is Goal.DailyWordCountGoal -> goal.initialDailyWordCount
-                is Goal.DeadlineGoal -> goal.adjustedDailyWordCount(entries)
+                is Goal.DeadlineGoal -> goal.adjustedDailyWordCount(selectedProjectEntries)
             }
             val title = buildString {
                 append(

--- a/app/src/main/java/com/sherryyuan/wordy/screens/entries/CalendarEntries.kt
+++ b/app/src/main/java/com/sherryyuan/wordy/screens/entries/CalendarEntries.kt
@@ -45,7 +45,7 @@ import com.kizitonwose.calendar.core.DayPosition
 import com.kizitonwose.calendar.core.nextMonth
 import com.kizitonwose.calendar.core.previousMonth
 import com.sherryyuan.wordy.R
-import com.sherryyuan.wordy.screens.entries.EntriesViewState.CalendarEntriesProgress
+import com.sherryyuan.wordy.screens.entries.EntriesViewState.CalendarEntryProgress
 import kotlinx.coroutines.launch
 import java.time.DayOfWeek
 import java.time.LocalDate
@@ -89,19 +89,19 @@ fun CalendarEntries(
             MonthHeader(daysOfWeek = daysOfWeek)
         },
         dayContent = { day ->
-            val dayEntries = entriesState.dailyEntries.firstOrNull {
+            val dayEntry = entriesState.dailyEntries.firstOrNull {
                 it.date == day.date
             }
             val isSelected = selectedDay == day
             DayContent(
                 calendarDay = day,
-                entries = dayEntries,
+                entry = dayEntry,
                 isSelected = isSelected,
                 onClick = {
-                    if (!isSelected) {
-                        selectedDay = day
+                    selectedDay = if (!isSelected) {
+                        day
                     } else {
-                        selectedDay = null
+                        null
                     }
                 }
             )
@@ -176,7 +176,7 @@ private fun MonthHeader(daysOfWeek: List<DayOfWeek>) {
 @Composable
 private fun DayContent(
     calendarDay: CalendarDay,
-    entries: EntriesViewState.CalendarEntries.DailyCalendarEntries?,
+    entry: EntriesViewState.CalendarEntries.DailyCalendarEntry?,
     isSelected: Boolean,
     onClick: (CalendarDay) -> Unit,
 ) {
@@ -194,12 +194,12 @@ private fun DayContent(
         contentAlignment = Alignment.Center,
     ) {
         if (calendarDay.position == DayPosition.MonthDate) {
-            when (val progress = entries?.progress) {
-                CalendarEntriesProgress.GoalAchieved -> GoalAchievedBackground()
-                CalendarEntriesProgress.GoalAchievedStreakStart -> GoalAchievedStreakStartBackground()
-                CalendarEntriesProgress.GoalAchievedStreakMiddle -> GoalAchievedStreakMiddleBackground()
-                CalendarEntriesProgress.GoalAchievedStreakEnd -> GoalAchievedStreakEndBackground()
-                is CalendarEntriesProgress.GoalProgress -> GoalProgressBackground(progress)
+            when (val progress = entry?.progress) {
+                CalendarEntryProgress.GoalAchieved -> GoalAchievedBackground()
+                CalendarEntryProgress.GoalAchievedStreakStart -> GoalAchievedStreakStartBackground()
+                CalendarEntryProgress.GoalAchievedStreakMiddle -> GoalAchievedStreakMiddleBackground()
+                CalendarEntryProgress.GoalAchievedStreakEnd -> GoalAchievedStreakEndBackground()
+                is CalendarEntryProgress.GoalProgress -> GoalProgressBackground(progress)
 
                 null -> Unit
             }
@@ -311,7 +311,7 @@ private fun GoalAchievedStreakEndBackground() {
 }
 
 @Composable
-private fun GoalProgressBackground(progress: CalendarEntriesProgress.GoalProgress) {
+private fun GoalProgressBackground(progress: CalendarEntryProgress.GoalProgress) {
     CircularProgressIndicator(
         modifier = Modifier
             .fillMaxSize()

--- a/app/src/main/java/com/sherryyuan/wordy/screens/entries/EntriesViewState.kt
+++ b/app/src/main/java/com/sherryyuan/wordy/screens/entries/EntriesViewState.kt
@@ -22,14 +22,14 @@ sealed class EntriesViewState(
 
     data class CalendarEntries(
         val dailyWordCountGoal: Int,
-        val dailyEntries: List<DailyCalendarEntries>,
+        val dailyEntries: List<DailyCalendarEntry>,
         override val startYearMonth: YearMonth,
     ) : EntriesViewState(startYearMonth) {
 
-        data class DailyCalendarEntries(
+        data class DailyCalendarEntry(
             val date: LocalDate,
-            val progress: CalendarEntriesProgress,
-            val entries: List<DailyEntry>,
+            val entry: DailyEntry,
+            val progress: CalendarEntryProgress,
         )
     }
 
@@ -40,11 +40,11 @@ sealed class EntriesViewState(
         val projectTitle: String,
     )
 
-    sealed interface CalendarEntriesProgress {
-        data object GoalAchieved : CalendarEntriesProgress
-        data object GoalAchievedStreakStart : CalendarEntriesProgress
-        data object GoalAchievedStreakMiddle : CalendarEntriesProgress
-        data object GoalAchievedStreakEnd : CalendarEntriesProgress
-        data class GoalProgress(val percentAchieved: Float) : CalendarEntriesProgress
+    sealed interface CalendarEntryProgress {
+        data object GoalAchieved : CalendarEntryProgress
+        data object GoalAchievedStreakStart : CalendarEntryProgress
+        data object GoalAchievedStreakMiddle : CalendarEntryProgress
+        data object GoalAchievedStreakEnd : CalendarEntryProgress
+        data class GoalProgress(val percentAchieved: Float) : CalendarEntryProgress
     }
 }

--- a/app/src/main/java/com/sherryyuan/wordy/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/sherryyuan/wordy/screens/home/HomeScreen.kt
@@ -57,6 +57,7 @@ import com.sherryyuan.wordy.ui.theme.VerticalSpacer
 import com.sherryyuan.wordy.ui.theme.WordyTheme
 import com.sherryyuan.wordy.ui.topAndSideContentPadding
 import java.time.Instant
+import java.time.LocalDate
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
@@ -180,7 +181,7 @@ private fun WordCountInput(
 
 @Composable
 private fun DailyWordCountChart(
-    wordCounts: Map<Long, Int>,
+    wordCounts: Map<LocalDate, Int>,
     wordCountGoal: Int,
 ) {
     val modelProducer = remember { CartesianChartModelProducer() }
@@ -190,7 +191,7 @@ private fun DailyWordCountChart(
     val xAxisDates = rememberXAxisDates(wordCounts.keys.toList())
     LaunchedEffect(Unit) {
         modelProducer.runTransaction {
-            columnSeries { series(wordCounts.keys, wordCounts.values) }
+            columnSeries { series(wordCounts.values) }
         }
     }
 
@@ -223,7 +224,7 @@ private fun DailyWordCountChart(
 
 @Composable
 private fun CumulativeWordCountChart(
-    wordCounts: Map<Long, Int>,
+    wordCounts: Map<LocalDate, Int>,
     wordCountGoal: Int,
 ) {
     val modelProducer = remember { CartesianChartModelProducer() }
@@ -260,13 +261,13 @@ private fun CumulativeWordCountChart(
 }
 
 @Composable
-private fun rememberXAxisDates(timestamps: List<Long>): List<String> {
+private fun rememberXAxisDates(dates: List<LocalDate>): List<String> {
     val dateTimeFormatter = DateTimeFormatter
         .ofPattern("MMM d")
         .withZone(ZoneId.systemDefault())
     return remember {
-        timestamps.map {
-            dateTimeFormatter.format(Instant.ofEpochMilli(it))
+        dates.map {
+            dateTimeFormatter.format(it)
         }
     }
 }

--- a/app/src/main/java/com/sherryyuan/wordy/screens/home/HomeViewState.kt
+++ b/app/src/main/java/com/sherryyuan/wordy/screens/home/HomeViewState.kt
@@ -1,5 +1,7 @@
 package com.sherryyuan.wordy.screens.home
 
+import java.time.LocalDate
+
 sealed interface HomeViewState {
     data object Loading : HomeViewState
 
@@ -10,7 +12,7 @@ sealed interface HomeViewState {
         val wordsToday: Int,
         val dailyWordCountGoal: Int,
         val selectedDisplayedChartRange: DisplayedChartRange,
-        val chartWordCounts: Map<Long, Int>, // date timestamp to word count
+        val chartWordCounts: Map<LocalDate, Int>,
     ) : HomeViewState
 
     enum class DisplayedChartRange {

--- a/app/src/main/java/com/sherryyuan/wordy/screens/newproject/CreateNewProjectViewModel.kt
+++ b/app/src/main/java/com/sherryyuan/wordy/screens/newproject/CreateNewProjectViewModel.kt
@@ -5,9 +5,9 @@ import androidx.lifecycle.viewModelScope
 import com.sherryyuan.wordy.entitymodels.Goal
 import com.sherryyuan.wordy.entitymodels.Project
 import com.sherryyuan.wordy.entitymodels.ProjectStatus
+import com.sherryyuan.wordy.repositories.ProjectRepository
 import com.sherryyuan.wordy.screens.newproject.CreateNewProjectViewState.NewProjectGoal
 import com.sherryyuan.wordy.screens.newproject.CreateNewProjectViewState.State
-import com.sherryyuan.wordy.repositories.ProjectRepository
 import com.sherryyuan.wordy.utils.DIGITS_REGEX
 import com.sherryyuan.wordy.utils.MAX_WORD_COUNT_DIGITS
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import java.time.LocalDate
 import javax.inject.Inject
 
 @HiltViewModel
@@ -69,18 +70,18 @@ class CreateNewProjectViewModel @Inject constructor(
         }
     }
 
-    fun updateStartDate(input: Long) {
+    fun updateStartDate(input: LocalDate) {
         val currentGoal = goal.value as? NewProjectGoal.Deadline ?: return
-        val updatedGoal = currentGoal.copy(projectStartDateMillis = input)
+        val updatedGoal = currentGoal.copy(projectStartDate = input)
         goal.value = updatedGoal
     }
 
-    fun updateEndDate(input: Long) {
+    fun updateEndDate(input: LocalDate) {
         val currentGoal = goal.value as? NewProjectGoal.Deadline ?: return
-        if (input <= currentGoal.projectStartDateMillis) {
+        if (input <= currentGoal.projectStartDate) {
             return // TODO show warning
         }
-        val updatedGoal = currentGoal.copy(targetProjectEndDateMillis = input)
+        val updatedGoal = currentGoal.copy(targetProjectEndDate = input)
         goal.value = updatedGoal
     }
 
@@ -127,8 +128,8 @@ class CreateNewProjectViewModel @Inject constructor(
             description = descriptionInput.value,
             goal = Goal.DeadlineGoal(
                 targetTotalWordCount = goal.targetTotalWordCount.toInt(),
-                startDateMillis = goal.projectStartDateMillis,
-                targetEndDateMillis = goal.targetProjectEndDateMillis,
+                startDate = goal.projectStartDate,
+                targetEndDate = goal.targetProjectEndDate,
             ),
             status = ProjectStatus.IN_PROGRESS,
         )

--- a/app/src/main/java/com/sherryyuan/wordy/screens/newproject/CreateNewProjectViewState.kt
+++ b/app/src/main/java/com/sherryyuan/wordy/screens/newproject/CreateNewProjectViewState.kt
@@ -1,7 +1,7 @@
 package com.sherryyuan.wordy.screens.newproject
 
-import com.sherryyuan.wordy.utils.getDaysBetween
-import java.util.Calendar
+import com.sherryyuan.wordy.utils.projectDaysCount
+import java.time.LocalDate
 
 data class CreateNewProjectViewState(
     val title: String = "",
@@ -22,18 +22,14 @@ data class CreateNewProjectViewState(
 
         data class Deadline(
             val targetTotalWordCount: String = "50000",
-            val projectStartDateMillis: Long = Calendar.getInstance().timeInMillis,
-            val targetProjectEndDateMillis: Long = Calendar.getInstance().apply {
-                add(Calendar.MONTH, 3)
-            }.timeInMillis,
+            val projectStartDate: LocalDate = LocalDate.now(),
+            val targetProjectEndDate: LocalDate = LocalDate.now().plusMonths(3L),
         ) : NewProjectGoal {
             override val saveButtonEnabled = targetTotalWordCount.isNotBlank()
             val dailyWordCount: Int
                 get() {
-                    // TODO handle case where start date is in wrong time zone (eg. select tomorrow but get 0 as days between when it should be 1)
-                    // start and end dates are inclusive
-                    val days = getDaysBetween(projectStartDateMillis, targetProjectEndDateMillis) + 1
-                    return (targetTotalWordCount.toInt() / days).toInt()
+                    val days = projectDaysCount(projectStartDate, targetProjectEndDate)
+                    return targetTotalWordCount.toInt() / days
                 }
         }
     }

--- a/app/src/main/java/com/sherryyuan/wordy/screens/projectslist/ProjectsListScreen.kt
+++ b/app/src/main/java/com/sherryyuan/wordy/screens/projectslist/ProjectsListScreen.kt
@@ -41,7 +41,6 @@ import com.sherryyuan.wordy.entitymodels.Project
 import com.sherryyuan.wordy.ui.theme.VerticalSpacer
 import com.sherryyuan.wordy.ui.topAndSideContentPadding
 import com.sherryyuan.wordy.utils.TOP_BAR_ANIMATION_KEY
-import com.sherryyuan.wordy.utils.toFormattedTimeString
 
 @OptIn(ExperimentalFoundationApi::class, ExperimentalSharedTransitionApi::class)
 @Composable
@@ -155,7 +154,12 @@ private fun ProjectCard(
                             text = stringResource(R.string.daily_goal_progress_template, wordCount),
                             color = MaterialTheme.colorScheme.secondary,
                         )
-                        Text(stringResource(R.string.daily_goal_goal_template, goal.initialDailyWordCount))
+                        Text(
+                            stringResource(
+                                R.string.daily_goal_goal_template,
+                                goal.initialDailyWordCount
+                            )
+                        )
                     }
 
                     is Goal.DeadlineGoal -> {
@@ -168,13 +172,11 @@ private fun ProjectCard(
                                 goal.targetTotalWordCount,
                             )
                         )
-                        val targetDate =
-                            goal.targetEndDateMillis.toFormattedTimeString("MMM d, yyyy")
                         Text(
                             stringResource(
                                 R.string.deadline_goal_goal_template,
                                 goal.targetTotalWordCount,
-                                targetDate,
+                                goal.targetEndDate.toString(),
                             )
                         )
                     }

--- a/app/src/main/java/com/sherryyuan/wordy/utils/DateUtils.kt
+++ b/app/src/main/java/com/sherryyuan/wordy/utils/DateUtils.kt
@@ -1,16 +1,20 @@
 package com.sherryyuan.wordy.utils
 
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
-import java.util.concurrent.TimeUnit
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
 
-fun getDaysBetween(startDateTimestamp: Long, endDateTimestamp: Long): Long {
-    val diffInMillis = endDateTimestamp - startDateTimestamp
-    return TimeUnit.DAYS.convert(diffInMillis, TimeUnit.MILLISECONDS)
-}
+// start and end dates are inclusive
+fun projectDaysCount(
+    startDate: LocalDate,
+    endDate: LocalDate,
+): Int = ChronoUnit.DAYS.between(startDate, endDate).toInt() + 1
 
-fun Long.toFormattedTimeString(pattern: String): String {
-    val formatter = SimpleDateFormat(pattern, Locale.getDefault())
-    return formatter.format(Date(this))
-}
+fun Long.toLocalDate(): LocalDate = Instant.ofEpochMilli(this)
+    .atZone(ZoneId.systemDefault())
+    .toLocalDate()
+
+fun LocalDate.toEpochMillis(): Long = atStartOfDay(ZoneId.systemDefault())
+    .toInstant()
+    .toEpochMilli()

--- a/app/src/main/java/com/sherryyuan/wordy/utils/EntriesUtils.kt
+++ b/app/src/main/java/com/sherryyuan/wordy/utils/EntriesUtils.kt
@@ -2,18 +2,9 @@ package com.sherryyuan.wordy.utils
 
 import com.sherryyuan.wordy.entitymodels.DailyEntry
 import java.time.LocalDate
-import java.time.ZoneId
-import java.util.concurrent.TimeUnit
 
 fun List<DailyEntry>.fromPastDays(days: Int): List<DailyEntry> {
-    return this.filter { entry ->
-        val midnight = LocalDate.now()
-            .atStartOfDay(ZoneId.systemDefault())
-            .toInstant()
-            .toEpochMilli()
-
-        val pastDaysMillis = TimeUnit.DAYS.toMillis(days.toLong() - 1)
-
-        entry.timestamp >= (midnight - pastDaysMillis)
+    return filter { entry ->
+        entry.date >= LocalDate.now().minusDays(days.toLong())
     }
 }


### PR DESCRIPTION
Using `LocalDate` instead of millis timestamp to simplify time calculations
Plus a bunch of smaller improvements/fixes
- Simplify `DailyCalendarEntry ` to have `entry` as a single `DailyEntry` instead of a list, since we only expect one entry per calendar day
- Fix goal streaks UI calculation - properly check whether "goal reached" entries are on consecutive days
- Don't include today's entries when calculating `adjustedDailyWordCount()`
- Add `projectDaysCount()` helper function to standardize counting days between start and end times, and prevent off-by-one errors since both are inclusive
- Fix `NotificationWorker` using all entries, instead of only current project's entries, when calling `adjustedDailyWordCount()` 